### PR TITLE
core: Make sure to initialize the default logger

### DIFF
--- a/examples/BasicLogger.cpp
+++ b/examples/BasicLogger.cpp
@@ -50,6 +50,9 @@ int main(int argc, const char* argv[])
 {
     // Set the global logger level to Debug
     logpp::setLevel(logpp::LogLevel::Debug);
+    auto formatter = std::make_shared<logpp::LogFmtFormatter>();
+    auto consoleOut = std::make_shared<logpp::sink::ColoredOutputConsole>(formatter);
+    logpp::defaultLogger()->setSink(consoleOut);
 
     // Uncomment this line to log lines in logfmt format
     // logpp::setFormatter<logpp::LogFmtFormatter>();

--- a/src/LoggerRegistry.cpp
+++ b/src/LoggerRegistry.cpp
@@ -127,6 +127,9 @@ namespace logpp
     std::shared_ptr<Logger> LoggerRegistry::defaultLogger()
     {
         std::lock_guard guard(m_mutex);
+        if (m_defaultLogger == nullptr) {
+          m_defaultLogger = m_defaultLoggerFactory("logpp");
+        }
         return m_defaultLogger;
     }
 


### PR DESCRIPTION
The default logger is never initialized, even if there is a default logger factory. As a result, the basic logger example segfaults when run. Note that by default, the default logger also doesn't have a sink, so we have to set one up in the example to get any output.